### PR TITLE
Escaping of recipient name

### DIFF
--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -714,6 +714,9 @@ def get_address(name, email):
     if LooseVersion(django.get_version()) < LooseVersion('1.9'):
         name = name.encode('ascii', 'ignore').decode('ascii').strip()
     if name:
+        name = name.replace('@', '') \
+                   .replace(',', '') \
+                   .replace(';', '')
         return u'%s <%s>' % (name, email)
     else:
         return u'%s' % email


### PR DESCRIPTION
In some cases, the subscription.name will contain special characters that cause the outgoing email to fail such as `@` and `,`.

Such real world example: when name is `'martin@'` and email is `martin@email.com`, it creates this address for sending `'martin@ <martin@email.com>'`, which fails.

I added a filter for these characters: `@`, `,` and `;` in the `get_address(name, email)` method.
There could be more, these are the real life cases that I faced.

I also considered changing it in the 'cleaning' part of `subscription.save` so that these faulty names don't even go into the database, but I decided to let them in the database and just filter them out when sending. Feel free to put your opinions about this in this PR.