### PR TITLE
Drop support for EOL Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['2.2', '3.1', '3.2', 'main']
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,12 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['2.2', '3.1', '3.2', 'main']
+        exclude:
+          # No such tox envs:
+          - {python-version: '3.7', django-version: 'main'}
+          - {python-version: '3.10', django-version: '2.2'}
+          - {python-version: '3.10', django-version: '3.1'}
+          - {python-version: '3.10', django-version: '3.2'}
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ soon as near-full coverage is reached.
 
 Compatibility
 =============
-Currently, django-newsletter officially supports Django 2.2.x LTS, 3.1.x and 3.2.x and Python 3.6 through 3.9.
+Currently, django-newsletter officially supports Django 2.2.x LTS, 3.1.x and 3.2.x and Python 3.7 through 3.10.
 
 Requirements
 ============

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # django-newsletter documentation build configuration file, created by
 # sphinx-quickstart on Wed Nov 13 13:53:07 2013.
@@ -76,8 +75,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'django-newsletter'
-copyright = u'2013, Mathijs de Bruin'
+project = 'django-newsletter'
+copyright = '2013, Mathijs de Bruin'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -224,8 +223,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'django-newsletter.tex', u'django-newsletter Documentation',
-   u'Mathijs de Bruin', 'manual'),
+  ('index', 'django-newsletter.tex', 'django-newsletter Documentation',
+   'Mathijs de Bruin', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -254,8 +253,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'django-newsletter', u'django-newsletter Documentation',
-     [u'Mathijs de Bruin'], 1)
+    ('index', 'django-newsletter', 'django-newsletter Documentation',
+     ['Mathijs de Bruin'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -268,8 +267,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'django-newsletter', u'django-newsletter Documentation',
-   u'Mathijs de Bruin', 'django-newsletter', 'One line description of project.',
+  ('index', 'django-newsletter', 'django-newsletter Documentation',
+   'Mathijs de Bruin', 'django-newsletter', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/newsletter/addressimport/parsers.py
+++ b/newsletter/addressimport/parsers.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext as _
 from newsletter.models import Subscription
 
 
-class AddressList(object):
+class AddressList:
     """ List with unique addresses. """
 
     def __init__(self, newsletter, ignore_errors=False):

--- a/newsletter/admin.py
+++ b/newsletter/admin.py
@@ -98,7 +98,7 @@ class NewsletterAdminLinkMixin:
     def admin_newsletter(self, obj):
         opts = Newsletter._meta
         newsletter = obj.newsletter
-        url = reverse('admin:%s_%s_change' % (opts.app_label, opts.model_name),
+        url = reverse(f'admin:{opts.app_label}_{opts.model_name}_change',
                       args=(newsletter.id,), current_app=self.admin_site.name)
 
         return format_html('<a href="{}">{}</a>', url, newsletter)

--- a/newsletter/management/__init__.py
+++ b/newsletter/management/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 # management commands for the newsletter

--- a/newsletter/management/commands/__init__.py
+++ b/newsletter/management/commands/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 # management commands for the newsletter

--- a/newsletter/management/commands/submit_newsletter.py
+++ b/newsletter/management/commands/submit_newsletter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 actual sending of the submissions
 """

--- a/newsletter/migrations/0001_initial.py
+++ b/newsletter/migrations/0001_initial.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 import sorl.thumbnail.fields
 import newsletter.utils
@@ -108,7 +105,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='subscription',
-            unique_together=set([('user', 'email_field', 'newsletter')]),
+            unique_together={('user', 'email_field', 'newsletter')},
         ),
         migrations.AddField(
             model_name='submission',
@@ -124,7 +121,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='message',
-            unique_together=set([('slug', 'newsletter')]),
+            unique_together={('slug', 'newsletter')},
         ),
         migrations.AddField(
             model_name='article',

--- a/newsletter/migrations/0002_auto_20150416_1555.py
+++ b/newsletter/migrations/0002_auto_20150416_1555.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models, migrations
 import django.db.models.manager
 import django.contrib.sites.managers

--- a/newsletter/migrations/0003_auto_20160226_1518.py
+++ b/newsletter/migrations/0003_auto_20160226_1518.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import logging
 logger = logging.getLogger(__name__)
 
@@ -34,6 +32,6 @@ class Migration(migrations.Migration):
         migrations.RunPython(renumerate_article_sortorder),
         migrations.AlterUniqueTogether(
             name='article',
-            unique_together=set([('post', 'sortorder')]),
+            unique_together={('post', 'sortorder')},
         ),
     ]

--- a/newsletter/migrations/0004_auto_20180407_1043.py
+++ b/newsletter/migrations/0004_auto_20180407_1043.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations, models
 import newsletter.models
 

--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -566,7 +566,7 @@ class Submission(models.Model):
     @cached_property
     def extra_headers(self):
         return {
-            'List-Unsubscribe': 'http://%s%s' % (
+            'List-Unsubscribe': 'http://{}{}'.format(
                 Site.objects.get_current().domain,
                 reverse('newsletter_unsubscribe_request',
                         args=[self.message.newsletter.slug])
@@ -743,6 +743,6 @@ def get_address(name, email):
     if LooseVersion(django.get_version()) < LooseVersion('1.9'):
         name = name.encode('ascii', 'ignore').decode('ascii').strip()
     if name:
-        return '%s <%s>' % (name, email)
+        return f'{name} <{email}>'
     else:
         return '%s' % email

--- a/newsletter/settings.py
+++ b/newsletter/settings.py
@@ -44,7 +44,7 @@ class Settings:
             try:
                 setting = getattr(
                     django_settings,
-                    '%s_%s' % (self.settings_prefix, attr),
+                    f'{self.settings_prefix}_{attr}',
                 )
             except AttributeError:
                 if not attr.startswith('DEFAULT_'):

--- a/newsletter/views.py
+++ b/newsletter/views.py
@@ -420,7 +420,7 @@ class ActionRequestView(ActionFormView):
         try:
             self.subscription.send_activation_email(action=self.action)
 
-        except (SMTPException, socket.error) as e:
+        except (SMTPException, OSError) as e:
             logger.exception(
                 'Error %s while submitting email to %s.',
                 e, self.subscription.email

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     url='http://github.com/jazzband/django-newsletter/',
     packages=find_packages(exclude=("tests", "test_project")),
     include_package_data=True,
+    python_requires='>=3.7',
     classifiers=[
         'Development Status :: 6 - Mature',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -68,11 +68,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3 :: Only',
         'Topic :: Utilities'
     ],
 )

--- a/tests/test_mailing.py
+++ b/tests/test_mailing.py
@@ -1,6 +1,5 @@
 import itertools
 import os
-import sys
 
 from unittest import mock
 import unittest
@@ -259,8 +258,6 @@ class SubmitSubmissionTestCase(MailingTestCase):
 
         sleep_mock.assert_called_with(0.02)
 
-    @unittest.skipIf(sys.version_info < (3,6), 
-                        reason="assert_called_once added in Python 3.6")
     def test_management_command(self):
         """ Test submission through management command. """
 
@@ -454,7 +451,7 @@ class TemplateOverridesTestCase(MailingTestCase, AllEmailsTestsMixin):
 
     def get_newsletter_kwargs(self):
         """
-        Update keyword arguments for instanciating the newsletter
+        Update keyword arguments for instantiating the newsletter
         so that slug corresponds to one for which template overrides exists
         and make sure e-mails will be sent with text and HTML versions.
         """

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -193,7 +193,7 @@ class UserNewsletterListTestCase(UserTestCase,
         for form in formset.forms:
             self.assertTrue(
                 form.instance.newsletter in self.newsletters,
-                "%s not in %s" % (form.instance.newsletter, self.newsletters)
+                f"{form.instance.newsletter} not in {self.newsletters}"
             )
             self.assertContains(response, form['id'])
             self.assertContains(response, form['subscribed'])
@@ -560,7 +560,7 @@ class AnonymousSubscribeTestCase(
         self.assertEqual(len(mail.outbox), 1)
 
         activate_url = subscription.subscribe_activate_url()
-        full_activate_url = 'http://%s%s' % (self.site.domain, activate_url)
+        full_activate_url = f'http://{self.site.domain}{activate_url}'
 
         self.assertEmailContains(full_activate_url)
 
@@ -895,7 +895,7 @@ class AnonymousSubscribeTestCase(
         self.assertEqual(len(mail.outbox), 1)
 
         activate_url = subscription.unsubscribe_activate_url()
-        full_activate_url = 'http://%s%s' % (self.site.domain, activate_url)
+        full_activate_url = f'http://{self.site.domain}{activate_url}'
 
         self.assertEmailContains(full_activate_url)
 
@@ -1034,7 +1034,7 @@ class AnonymousSubscribeTestCase(
         self.assertEqual(len(mail.outbox), 1)
 
         activate_url = subscription.update_activate_url()
-        full_activate_url = 'http://%s%s' % (self.site.domain, activate_url)
+        full_activate_url = f'http://{self.site.domain}{activate_url}'
 
         self.assertEmailContains(full_activate_url)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39}-dj{22,31}
-    py{37,38,39}-dj32
+    py{37,38,39}-dj{22,31,32}
     py{38,39,310}-djmain
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,31}
-    py{36,37,38,39}-dj32
+    py{37,38,39}-dj{22,31}
+    py{37,38,39}-dj32
     py{38,39,310}-djmain
 
 [testenv]
@@ -14,7 +14,6 @@ deps =
     pytz
     webtest
     django-webtest
-    mock
     dj22: Django>=2.2,<3.0
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
@@ -32,7 +31,6 @@ setenv =
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
Python 3.6 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.1 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |

https://endoflife.date/python

Also add `python_requires` metadata to help pip and upgrade Python syntax with https://github.com/asottile/pyupgrade/