### PR TITLE
Using importlib instead of pkg_resources

### DIFF
--- a/newsletter/__init__.py
+++ b/newsletter/__init__.py
@@ -1,7 +1,26 @@
-from pkg_resources import get_distribution, DistributionNotFound
+PACKAGE_NAME = "django-newsletter"
+
+# importlib is available in python >= 3.8.
+# Remove the except importError once support for python < 3.8 is dropped.
 
 try:
-    __version__ = get_distribution("django-newsletter").version
-except DistributionNotFound:
-    # package is not installed
-    __version__ = None
+    from importlib.metadata import distribution, PackageNotFoundError
+
+    def get_distribution_version():
+        try:
+            return distribution(PACKAGE_NAME).version
+        except PackageNotFoundError:
+            # package is not installed
+            return None
+except ImportError:
+    from pkg_resources import get_distribution, DistributionNotFound
+
+    def get_distribution_version():
+        try:
+            return get_distribution(PACKAGE_NAME).version
+        except DistributionNotFound:
+            # package is not installed
+            return None
+
+
+__version__ = get_distribution_version()


### PR DESCRIPTION
To address this deprecation warning https://github.com/jazzband/django-newsletter/issues/390 I changed from `pkg_resources` to `importlib`. 

Since `importlib` is available since Python 3.8 and django-newsletter supports Python 3.7, I included a conditional import which defaults to `pkg_resources`.