### PR TITLE
Fix for missing `thumbnail_template` in html template context

### DIFF
--- a/newsletter/admin.py
+++ b/newsletter/admin.py
@@ -310,13 +310,24 @@ class MessageAdmin(NewsletterAdminLinkMixin, ExtendibleModelAdminMixin,
                 'message belongs to.'
             ))
 
+        # Determines the appropriate template to display a thumbnail
+        if newsletter_settings.THUMBNAIL == 'sorl-thumbnail':
+            thumbnail_template = (
+                'newsletter/message/thumbnail/sorl_thumbnail.html'
+            )
+        elif newsletter_settings.THUMBNAIL == 'easy-thumbnails':
+            thumbnail_template = (
+                'newsletter/message/thumbnail/easy_thumbnails.html'
+            )
+
         c = {
             'message': message,
             'site': Site.objects.get_current(),
             'newsletter': message.newsletter,
             'date': now(),
             'STATIC_URL': settings.STATIC_URL,
-            'MEDIA_URL': settings.MEDIA_URL
+            'MEDIA_URL': settings.MEDIA_URL,
+            'thumbnail_template': thumbnail_template
         }
 
         return HttpResponse(message.html_template.render(c))

--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -613,6 +613,16 @@ class Submission(models.Model):
             'MEDIA_URL': settings.MEDIA_URL
         }
 
+        # Determines the appropriate template to display a thumbnail
+        if settings.NEWSLETTER_THUMBNAIL == 'sorl-thumbnail':
+            variable_dict['thumbnail_template'] = (
+                'newsletter/message/thumbnail/sorl_thumbnail.html'
+            )
+        elif settings.NEWSLETTER_THUMBNAIL == 'easy-thumbnails':
+            variable_dict['thumbnail_template'] = (
+                'newsletter/message/thumbnail/easy_thumbnails.html'
+            )
+
         subject = self.message.subject_template.render(
             variable_dict).strip()
         text = self.message.text_template.render(variable_dict)


### PR DESCRIPTION
The `{% include thumbnail_template %}` tag in message's html template raised an error because it could not find the `thumbnail_template` in the context. This happened when trying to send the message via the `Submission` record or when trying to preview.