### PR TITLE
App config to specify default BigAutoField

### DIFF
--- a/newsletter/apps.py
+++ b/newsletter/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class NewsletterConfig(AppConfig):
+    name = "newsletter"
+    verbose_name = "Newsletter"
+    default_auto_field = "django.db.models.BigAutoField"


### PR DESCRIPTION
I'm adding an AppConfig to specify `BigAutoField` as default for this app, to prevent conflicts with projects that use `AutoField`. We are using `BigAutoField` since https://github.com/jazzband/django-newsletter/commit/00bf86d2d19f09bb816f2ecadc76df22f87286bc