### PR TITLE
making admin action actually subscribe/unsuscribe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changes
 - Add support for Python 3.13
 - Add support for Django 5.2
 - Add setting to configure thumbnail size
+- Fix bug in Subscription admin actions
 
 1.0 (11-12-2024)
 ---------------

--- a/newsletter/admin.py
+++ b/newsletter/admin.py
@@ -440,7 +440,9 @@ class SubscriptionAdmin(NewsletterAdminLinkMixin, ExtendibleModelAdminMixin,
 
     """ Actions """
     def make_subscribed(self, request, queryset):
-        rows_updated = queryset.update(subscribed=True)
+        for subscription in queryset.all():
+            subscription.update('subscribe')
+        rows_updated = queryset.count()
         self.message_user(
             request,
             ngettext(
@@ -452,7 +454,9 @@ class SubscriptionAdmin(NewsletterAdminLinkMixin, ExtendibleModelAdminMixin,
     make_subscribed.short_description = _("Subscribe selected users")
 
     def make_unsubscribed(self, request, queryset):
-        rows_updated = queryset.update(subscribed=False)
+        for subscription in queryset.all():
+            subscription.update('unsubscribe')
+        rows_updated = queryset.count()
         self.message_user(
             request,
             ngettext(


### PR DESCRIPTION
Admin actions "subscribe/unsubscribe selected users" was updating queryset directly so it was not calling `save()`. This means skipping all the checks that go in that method, so it left the objects in an inconsistent state.