### PR TITLE
Fix thumbnail template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changes
 - Add support for Python 3.13
 - Add support for Django 5.2
 - Add setting to configure thumbnail size
+- Fix thumbnail template not found error
 - Fix bug in Subscription admin actions
 
 1.0 (11-12-2024)

--- a/newsletter/admin.py
+++ b/newsletter/admin.py
@@ -311,14 +311,14 @@ class MessageAdmin(NewsletterAdminLinkMixin, ExtendibleModelAdminMixin,
                 'message belongs to.'
             ))
 
-        html = render_message(message, None, None, now())[2]
+        html = render_message(message, now())[2]
 
         return HttpResponse(html)
 
     @xframe_options_sameorigin
     def preview_text(self, request, object_id):
         message = self._getobj(request, object_id)
-        text = render_message(message, None, None, now())[1]
+        text = render_message(message, now())[1]
         return HttpResponse(text, content_type='text/plain')
 
     def submit(self, request, object_id):

--- a/newsletter/admin.py
+++ b/newsletter/admin.py
@@ -42,7 +42,8 @@ except (ImportError, RuntimeError):
     pass
 
 from .models import (
-    Newsletter, Subscription, Attachment, Article, Message, Submission
+    Newsletter, Subscription, Attachment, Article, Message, Submission,
+    render_message
 )
 
 from django.utils.timezone import now
@@ -310,34 +311,15 @@ class MessageAdmin(NewsletterAdminLinkMixin, ExtendibleModelAdminMixin,
                 'message belongs to.'
             ))
 
-        c = {
-            'message': message,
-            'site': Site.objects.get_current(),
-            'newsletter': message.newsletter,
-            'date': now(),
-            'STATIC_URL': settings.STATIC_URL,
-            'MEDIA_URL': settings.MEDIA_URL
-        }
+        html = render_message(message, None, None, now())[2]
 
-        return HttpResponse(message.html_template.render(c))
+        return HttpResponse(html)
 
     @xframe_options_sameorigin
     def preview_text(self, request, object_id):
         message = self._getobj(request, object_id)
-
-        c = {
-            'message': message,
-            'site': Site.objects.get_current(),
-            'newsletter': message.newsletter,
-            'date': now(),
-            'STATIC_URL': settings.STATIC_URL,
-            'MEDIA_URL': settings.MEDIA_URL
-        }
-
-        return HttpResponse(
-            message.text_template.render(c),
-            content_type='text/plain'
-        )
+        text = render_message(message, None, None, now())[1]
+        return HttpResponse(text, content_type='text/plain')
 
     def submit(self, request, object_id):
         submission = Submission.from_message(self._getobj(request, object_id))

--- a/newsletter/fields.py
+++ b/newsletter/fields.py
@@ -1,24 +1,13 @@
 """Model fields for django-newsletter."""
-from django.db.models import ImageField
 from django.core.exceptions import ImproperlyConfigured
-
-# Conditional imports as only one Thumbnail app is required
-try:
-    from sorl.thumbnail.fields import ImageField as SorlImageField
-except ImportError:
-    pass
-
-try:
-    from easy_thumbnails.fields import ThumbnailerImageField
-except (ImportError, RuntimeError):
-    pass
-
 from .settings import newsletter_settings
 
 # Uses the model field provided by the thumbnailing application
 if newsletter_settings.THUMBNAIL == 'sorl-thumbnail':
+    from sorl.thumbnail.fields import ImageField as SorlImageField
     ParentClass = SorlImageField
 elif newsletter_settings.THUMBNAIL == 'easy-thumbnails':
+    from easy_thumbnails.fields import ThumbnailerImageField
     ParentClass = ThumbnailerImageField
 else:
     raise ImproperlyConfigured('Invalid NEWSLETTER_THUMBNAIL value.')

--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -16,6 +16,7 @@ from django.utils.timezone import now
 from django.urls import reverse
 
 from .fields import DynamicImageField
+from .settings import newsletter_settings
 from .utils import (
     make_activation_code, get_default_sites, ACTIONS
 )
@@ -560,7 +561,8 @@ def render_message(message, submission, subscription, date):
         'site': Site.objects.get_current(),
         'date': date,
         'STATIC_URL': settings.STATIC_URL,
-        'MEDIA_URL': settings.MEDIA_URL
+        'MEDIA_URL': settings.MEDIA_URL,
+        'thumbnail_template': newsletter_settings.THUMBNAIL_TEMPLATE,
     }
     subject = message.subject_template.render(variable_dict)
     text = message.text_template.render(variable_dict)

--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -552,21 +552,29 @@ class Message(models.Model):
             return None
 
 
-def render_message(message, submission, subscription, date):
-    variable_dict = {
+def get_render_context(message, date, submission=None, subscription=None, attachment_links=False):
+    return {
         'message': message,
         'newsletter': message.newsletter,
         'subscription': subscription,
         'submission': submission,
         'site': Site.objects.get_current(),
         'date': date,
+        'attachment_links': attachment_links,
         'STATIC_URL': settings.STATIC_URL,
         'MEDIA_URL': settings.MEDIA_URL,
         'thumbnail_template': newsletter_settings.THUMBNAIL_TEMPLATE,
     }
-    subject = message.subject_template.render(variable_dict)
-    text = message.text_template.render(variable_dict)
-    html = message.html_template.render(variable_dict) \
+
+
+def render_message(message, date, submission=None, subscription=None, attachment_links=False):
+    context = get_render_context(
+        message, date,
+        submission=submission, subscription=subscription, attachment_links=attachment_links
+    )
+    subject = message.subject_template.render(context)
+    text = message.text_template.render(context)
+    html = message.html_template.render(context) \
         if message.html_template else None
     return subject.strip(), text.strip(), html and html.strip()
 

--- a/newsletter/settings.py
+++ b/newsletter/settings.py
@@ -6,6 +6,11 @@ from django.core.exceptions import ImproperlyConfigured
 
 from .utils import Singleton
 
+SUPPORTED_THUMBNAILERS = {
+    'sorl-thumbnail': 'newsletter/message/thumbnail/sorl_thumbnail.html',
+    'easy-thumbnails': 'newsletter/message/thumbnail/easy_thumbnails.html'
+}
+
 
 class Settings:
     """
@@ -106,45 +111,30 @@ class NewsletterSettings(Settings):
     @property
     def THUMBNAIL(self):
         """Validates and returns the set thumbnail application."""
-        SUPPORTED_THUMBNAILERS = [
-            'sorl-thumbnail',
-            'easy-thumbnails',
-        ]
-        THUMBNAIL = getattr(
+        thumbnail = getattr(
             django_settings, 'NEWSLETTER_THUMBNAIL', None
         )
 
         # Checks that the user entered a value
-        if THUMBNAIL is None:
+        if thumbnail is None:
             warnings.warn(
-                (
-                    'No NEWSLETTER_THUMBNAIL setting specified - '
-                    'sorl-thumbnail will be used by default. '
-                    'django-newsletter version 0.11.0 will require an '
-                    'explicit declaration of the preferred thumbnailer.'
-                ),
-                DeprecationWarning
+                'No NEWSLETTER_THUMBNAIL setting specified - '
+                'sorl-thumbnail will be used by default.'
             )
-
-            return 'sorl-thumbnail'
+            thumbnail = 'sorl-thumbnail'
 
         # Checks for a supported thumbnailer
-        if THUMBNAIL in SUPPORTED_THUMBNAILERS:
-            return THUMBNAIL
+        if thumbnail in SUPPORTED_THUMBNAILERS:
+            return thumbnail
 
         # Otherwise user has not set thumbnailer correctly
         raise ImproperlyConfigured(
-            "'%s' is not a supported thumbnail application." % THUMBNAIL
+            "'%s' is not a supported thumbnail application." % thumbnail
         )
 
     @property
     def THUMBNAIL_TEMPLATE(self):
-        if self.THUMBNAIL == 'sorl-thumbnail':
-            return 'newsletter/message/thumbnail/sorl_thumbnail.html'
-        elif newsletter_settings.THUMBNAIL == 'easy-thumbnails':
-            return 'newsletter/message/thumbnail/easy_thumbnails.html'
-        else:
-            return None
+        return self.THUMBNAIL and SUPPORTED_THUMBNAILERS[self.THUMBNAIL]
 
 
 newsletter_settings = NewsletterSettings()

--- a/newsletter/settings.py
+++ b/newsletter/settings.py
@@ -137,4 +137,14 @@ class NewsletterSettings(Settings):
             "'%s' is not a supported thumbnail application." % THUMBNAIL
         )
 
+    @property
+    def THUMBNAIL_TEMPLATE(self):
+        if self.THUMBNAIL == 'sorl-thumbnail':
+            return 'newsletter/message/thumbnail/sorl_thumbnail.html'
+        elif newsletter_settings.THUMBNAIL == 'easy-thumbnails':
+            return 'newsletter/message/thumbnail/easy_thumbnails.html'
+        else:
+            return None
+
+
 newsletter_settings = NewsletterSettings()

--- a/newsletter/views.py
+++ b/newsletter/views.py
@@ -2,6 +2,7 @@ import logging
 
 import datetime
 import socket
+from doctest import UnexpectedException
 
 from smtplib import SMTPException
 
@@ -584,29 +585,16 @@ class SubmissionArchiveDetailView(SubmissionViewBase, DateDetailView):
         """
         Make sure the actual message is available.
         """
-        context = \
-            super().get_context_data(**kwargs)
-
-        message = self.object.message
-
-        # Determines the appropriate template to display a thumbnail
-        if newsletter_settings.THUMBNAIL == 'sorl-thumbnail':
-            thumbnail_template = (
-                'newsletter/message/thumbnail/sorl_thumbnail.html'
-            )
-        elif newsletter_settings.THUMBNAIL == 'easy-thumbnails':
-            thumbnail_template = (
-                'newsletter/message/thumbnail/easy_thumbnails.html'
-            )
+        context = super().get_context_data(**kwargs)
 
         context.update({
-            'message': message,
+            'message': self.object.message,
             'attachment_links': True,
             'site': Site.objects.get_current(),
             'date': self.object.publish_date,
             'STATIC_URL': settings.STATIC_URL,
             'MEDIA_URL': settings.MEDIA_URL,
-            'thumbnail_template': thumbnail_template,
+            'thumbnail_template': newsletter_settings.THUMBNAIL_TEMPLATE,
         })
 
         return context

--- a/newsletter/views.py
+++ b/newsletter/views.py
@@ -31,7 +31,7 @@ from django.urls import reverse
 
 from django.forms.models import modelformset_factory
 
-from .models import Newsletter, Subscription, Submission
+from .models import Newsletter, Subscription, Submission, get_render_context
 from .forms import (
     SubscribeRequestForm, UserUpdateForm, UpdateRequestForm,
     UnsubscribeRequestForm, UpdateForm
@@ -586,17 +586,12 @@ class SubmissionArchiveDetailView(SubmissionViewBase, DateDetailView):
         Make sure the actual message is available.
         """
         context = super().get_context_data(**kwargs)
-
-        context.update({
-            'message': self.object.message,
-            'attachment_links': True,
-            'site': Site.objects.get_current(),
-            'date': self.object.publish_date,
-            'STATIC_URL': settings.STATIC_URL,
-            'MEDIA_URL': settings.MEDIA_URL,
-            'thumbnail_template': newsletter_settings.THUMBNAIL_TEMPLATE,
-        })
-
+        context.update(
+            get_render_context(
+                self.object.message, self.object.publish_date,
+                submission=self.object, attachment_links=True
+            )
+        )
         return context
 
     def get_template(self):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -275,21 +275,9 @@ class AdminTestCase(AdminTestMixin, TestCase):
             html=True
         )
 
-        response = self.client.get(preview_text_url)
-        self.assertEqual(
-            response.content,
-            b'''++++++++++++++++++++
-
-Test Newsletter: Test message
-
-++++++++++++++++++++
-
-
-
-++++++++++++++++++++
-
-Unsubscribe: http://example.com/newsletter/test-newsletter/unsubscribe/
-''')
+        response_content = self.client.get(preview_text_url).content.decode('utf-8')
+        self.assertIn('Test Newsletter: Test message', response_content)
+        self.assertIn(self.newsletter.unsubscribe_url(), response_content)
 
         response = self.client.get(preview_html_url)
         self.assertContains(response, '<h1>Test Newsletter</h1>')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -124,15 +124,11 @@ class SettingsTestCase(TestCase):
         Test that ``None`` raises warning and defaults to sorl-thubmanil.
         """
 
-        with self.assertWarns(DeprecationWarning) as context_manager:
+        with self.assertWarns(UserWarning) as context_manager:
             self.assertEqual(newsletter_settings.THUMBNAIL, 'sorl-thumbnail')
 
         self.assertIn(
             'No NEWSLETTER_THUMBNAIL setting specified',
-            str(context_manager.warning)
-        )
-        self.assertIn(
-            'django-newsletter version 0.11.0',
             str(context_manager.warning)
         )
 


### PR DESCRIPTION
This is a fix for https://github.com/jazzband/django-newsletter/issues/396

I made sure all rendering paths use the same context which includes the `thumbnail_template`. Also extracted rendering message into its own method (`render_message`) to separate it from the actual sending of the message. All to support DRY.

Added `THUMBNAIL_TEMPLATE` property in newsletter_settings.

I made conditional imports actually conditional on `THUMBNAIL` and they will fail if needed (as should be).

Also removed the deprecation warning as was scheduled for a long time ago (version 0.11) and not enforced. I replaced it with a UserWarning.