### PR TITLE
moving optional dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,19 @@ Currently, django-newsletter officially supports Django 4.2.x LTS, 5.0.x and 5.1
 
 Requirements
 ============
-Please refer to `requirements.txt <http://github.com/jazzband/django-newsletter/blob/master/requirements.txt>`_
+Please refer to `setup.py <http://github.com/jazzband/django-newsletter/blob/master/setup.py>`_
 for an updated list of required packages.
+
+Also, you will need to install either one of these to use as a thumbnail engine:
+
+* sorl-thumbnail
+* easy-thumbnails
+
+Additional dependencies that need to be installed separately:
+
+* python-ldap: for importing ldif files
+* unicodecsv: for importing csv files
+* python-card-me: for importing vCard files
 
 Tests
 ==========

--- a/setup.py
+++ b/setup.py
@@ -44,12 +44,18 @@ setup(
     long_description=README,
     install_requires=[
         "Django>=4.2",
-        "python-card-me<1.0",
-        "python-ldap",
         "chardet",
-        "unicodecsv<0.15",
         "Pillow",
     ],
+    extras_require={
+        "test": [
+            "python-ldap",
+            "unicodecsv",
+            "python-card-me",
+            "django-tinymce",
+            "django-imperavi"
+        ],
+    },
     author='Mathijs de Bruin',
     author_email='mathijs@mathijsfietst.nl',
     url='http://github.com/jazzband/django-newsletter/',

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,6 @@ envlist =
 [testenv]
 deps =
     coverage
-    django-imperavi
-    django-tinymce
     pytz
     webtest
     django-webtest
@@ -16,6 +14,8 @@ deps =
     dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<5.3
     djmain: https://github.com/django/django/archive/main.tar.gz
+extras =
+    test
 usedevelop = True
 ignore_outcome =
     djmain: True


### PR DESCRIPTION
Making dependencies minimum by moving additional requirements to extras_require.test in setup.py